### PR TITLE
feat: add readonly view mode for externally embedded views

### DIFF
--- a/app/components/BrandingOverlayForm.tsx
+++ b/app/components/BrandingOverlayForm.tsx
@@ -21,9 +21,11 @@ import ImageField from "./ImageField";
 
 export default function BrandingOverlayForm({
   overlay,
+  readonly = false
 }: {
   overlay?: OverlayBundle;
   language?: string;
+  readonly: boolean;
 }) {
   const branding = useBranding();
   const dispatch = useBrandingDispatch();
@@ -47,7 +49,7 @@ export default function BrandingOverlayForm({
   }, [overlay, dispatch]);
 
   return (
-    <div id="overlay-bundle-branding-form">
+    readonly || <div id="overlay-bundle-branding-form">
       <div id="overlay-bundle-branding-form-fields">
         <ImageField
           id="logo"

--- a/app/components/OverlayBundleView.tsx
+++ b/app/components/OverlayBundleView.tsx
@@ -23,7 +23,15 @@ import { Info } from "@mui/icons-material";
 import { CredentialExchangeRecord, CredentialPreviewAttribute, CredentialState } from "@aries-framework/core";
 import { fetchOverlayBundleData } from "@/app/lib/data";
 
-export default function OverlaBundleView({ option }: { option: any }) {
+export default function OverlaBundleView(
+  {
+    option,
+    readonly = false
+  }: {
+    option: any,
+    readonly: boolean
+  }
+) {
   const [overlayData, setOverlayData] = useState<{
     overlay: OverlayBundle | undefined;
     record: CredentialExchangeRecord | undefined;
@@ -155,7 +163,7 @@ export default function OverlaBundleView({ option }: { option: any }) {
           </Grid>
         </Grid>
         <Grid>
-          <OverlayBrandingForm overlay={overlayData?.overlay} language={language} />
+          <OverlayBrandingForm overlay={overlayData?.overlay} language={language} readonly={readonly} />
         </Grid>
       </Grid>
     </BrandingProvider>

--- a/app/identifier/[id]/page.tsx
+++ b/app/identifier/[id]/page.tsx
@@ -1,3 +1,4 @@
+import Header from "@/app/components/Header";
 import OverlayBundleView from "@/app/components/OverlayBundleView";
 import { fetchOverlayBundleList } from "@/app/lib/data";
 import { notFound } from "next/navigation";
@@ -8,8 +9,18 @@ export async function generateStaticParams() {
     ({ id: process.env.NODE_ENV === 'development' ? encodeURIComponent(option.id) : option.id }));
 }
 
-export default async function Page({ params }: { params: { id: string } }) {
+export default async function Page(
+  {
+    params,
+    searchParams
+  }: {
+    params: { id: string },
+    searchParams: URLSearchParams
+  }
+) {
   const id = decodeURIComponent(params.id);
+  const search = new URLSearchParams(searchParams);
+  const readonly = search.get('view') === 'readonly';
   const options: any[] = await fetchOverlayBundleList();
   const option = options.find((option) => option.id === id);
 
@@ -17,5 +28,12 @@ export default async function Page({ params }: { params: { id: string } }) {
     notFound();
   }
 
-  return <OverlayBundleView option={option} />;
+  return (
+    <>
+      {readonly || <Header />}
+      <main className='app min-h-screen'>
+        <OverlayBundleView option={option} readonly={readonly} />
+      </main>
+    </>
+  );
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,7 +1,6 @@
 import type { Metadata } from 'next';
 import { Inter } from 'next/font/google';
-import './globals.css';
-import Header from '@/app/components/Header';
+import '@/app/globals.css';
 import { StyledEngineProvider, ThemeProvider } from "@mui/material/styles";
 import { CssBaseline } from "@mui/material";
 import { theme } from '@/app/theme';
@@ -24,10 +23,7 @@ export default function RootLayout({
         <StyledEngineProvider injectFirst>
           <CssBaseline />
           <ThemeProvider theme={theme}>
-            <Header />
-            <main className='app min-h-screen'>
-              {children}
-            </main>
+            {children}
           </ThemeProvider>
         </StyledEngineProvider>
       </body>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,8 +1,16 @@
-import OverlayBundleForm from './components/OverlayBundleForm';
-import { fetchOverlayBundleList } from './lib/data';
+import Header from '@/app/components/Header';
+import OverlayBundleForm from '@/app/components/OverlayBundleForm';
+import { fetchOverlayBundleList } from '@/app/lib/data';
 
 export default async function Page() {
   const options = await fetchOverlayBundleList();
 
-  return <OverlayBundleForm options={options} />;
+  return (
+    <>
+      <Header />
+      <main className='app min-h-screen'>
+        <OverlayBundleForm options={options} />
+      </main>
+    </>
+  );
 }


### PR DESCRIPTION
This PR adds a view mode to hide the header and overlay bundle form actions, in order to support embedding static views in external sites.

The view mode can be enabled by adding a `URLSeachParameter`: `?view=readonly` to the URL.

Resolves: #13 
