### PR TITLE
Fix: align credential detail route encoding with SSG (encodeURIComponent)

### DIFF
--- a/app/components/EnhancedCredentialFilter.tsx
+++ b/app/components/EnhancedCredentialFilter.tsx
@@ -90,11 +90,8 @@ export default function EnhancedCredentialFilter({ options }: EnhancedCredential
       // Add a small delay to show the loading animation
       await new Promise(resolve => setTimeout(resolve, 300));
 
-      // Use base64 encoding to match static generation (browser-compatible)
-      const encodedId = btoa(bundle.id)
-        .replace(/\+/g, '-')
-        .replace(/\//g, '_')
-        .replace(/=/g, '');
+      // Use URL encoding to match static generation and server output
+      const encodedId = encodeURIComponent(bundle.id);
 
       // Use relative path for client-side navigation to work with basePath
       // Include trailing slash to match Next.js trailingSlash: true config


### PR DESCRIPTION
This PR fixes 404s on credential detail pages by aligning client-side navigation with static export paths.\n\nChanges:\n- Use encodeURIComponent for credential IDs in EnhancedCredentialFilter navigation to match generateStaticParams and exported directories.\n- Preserve trailing slash to respect trailingSlash: true.\n\nWhy:\n- Previously used URL-safe base64, which didn\'t correspond to any pre-rendered paths, causing 404s on GitHub Pages.\n- Now the encoded IDs match the SSG output, so pages resolve correctly on the main site.\n\nSite: https://bcgov.github.io/aries-oca-explorer/\n\nSigned-off-by: Kyle Robinson <kyle.robinson@briartech.ca>