### PR TITLE
Fix did:webvh credential detail pages: encode IDs to prevent path separator issues

### DIFF
--- a/app/identifier/[id]/page.tsx
+++ b/app/identifier/[id]/page.tsx
@@ -22,10 +22,10 @@ export async function generateStaticParams() {
     throw new Error(`Failed to fetch bundle list during static generation: ${error instanceof Error ? error.message : 'Unknown error'}. This will cause 404s for all credential detail pages.`);
   }
 
-  // Return raw IDs - Next.js will automatically encode them when creating file paths
-  // and decode them when passing to the Page component
+  // Encode IDs to prevent Next.js from treating / as path separator during static export
+  // This matches the encoding used in EnhancedCredentialFilter navigation
   const staticIds = Array.from(allIds).map((id) => ({
-    id: id
+    id: encodeURIComponent(id)
   }));
 
   console.log(`generateStaticParams: Generated ${staticIds.length} static pages for credential identifiers`);
@@ -38,22 +38,15 @@ export const dynamic = 'force-static';
 export const dynamicParams = false;
 
 export default async function Page({ params }: { params: { id: string } }) {
-  // Decode the ID - Next.js encodes it when processing the route parameter
-  // Use decodeURIComponent to properly decode all encoded characters (%2F, %3A, etc.)
-  let id = params.id;
-
-  // Always try to decode - Next.js will encode the ID in the URL
+  // Decode the ID - it was encoded in generateStaticParams to prevent path issues
+  let id: string;
   try {
-    id = decodeURIComponent(id);
+    id = decodeURIComponent(params.id);
   } catch (e) {
-    // If decoding fails, try manual decoding of just slashes (fallback)
-    if (id.includes('%2F')) {
-      id = id.replace(/%2F/g, '/');
-    }
-    // Also try to decode colons if they're encoded
-    if (id.includes('%3A')) {
-      id = id.replace(/%3A/g, ':');
-    }
+    // If decoding fails, log and return 404
+    console.error('Failed to decode ID:', params.id, e);
+    notFound();
+    return;
   }
 
   try {


### PR DESCRIPTION
## Problem
The did:webvh credential detail pages were returning 404 errors. Identifiers containing forward slashes (e.g., `did:webvh:.../resources/...`) were causing Next.js to create nested directory structures during static export instead of single files, resulting in broken URLs.

## Solution
Encode credential IDs in `generateStaticParams` using `encodeURIComponent` to prevent Next.js from treating forward slashes as path separators. This ensures:
- Forward slashes (`/`) are encoded as `%2F` in file paths
- Single files are created instead of nested directories
- Navigation URLs match the generated file paths
- IDs are properly decoded when rendering pages

## Changes
- Encode IDs in `generateStaticParams` using `encodeURIComponent`
- Simplify decoding in Page component with proper error handling
- Matches encoding already used in `EnhancedCredentialFilter` navigation

## Testing
After deployment, did:webvh credential detail pages should load correctly without 404 errors.