### PR TITLE
fix: improve README fetch resilience for LTSA bundle

### DIFF
--- a/app/lib/data.ts
+++ b/app/lib/data.ts
@@ -374,7 +374,7 @@ export async function fetchSchemaReadme(ocabundle: string): Promise<{
       if (isTimeout) {
         if (attempt < maxRetries) {
           // Exponential backoff: 2s, 4s, 8s with jitter
-          const delay = (Math.pow(2, attempt) * 1000) + Math.random() * 1000;
+          const delay = (Math.pow(2, attempt + 1) * 1000) + Math.random() * 1000;
           console.log(`Retry ${attempt + 1}/${maxRetries} for README: ${ocabundle} after ${Math.round(delay)}ms`);
           await new Promise(resolve => setTimeout(resolve, delay));
           continue;

--- a/app/lib/data.ts
+++ b/app/lib/data.ts
@@ -42,11 +42,18 @@ export interface BundleFilters {
 }
 
 // Cache for README content to avoid repeated fetches
+// Includes timestamp for TTL-based expiration
 const readmeCache = new Map<string, {
   ledger?: string;
   ledgerUrl?: string;
   ledgerMap?: Map<string, { ledger: string; ledgerUrl?: string }>;
+  timestamp: number;
 }>();
+
+// Cache TTL for successful README fetches: 10 minutes
+const README_CACHE_TTL = 10 * 60 * 1000;
+// Cache TTL for failed README fetches: 30 seconds (short to allow retry later)
+const README_FAIL_CACHE_TTL = 30 * 1000;
 
 // Cache for bundle list to ensure consistency across generateStaticParams and page rendering
 let bundleListCache: {
@@ -307,13 +314,22 @@ export async function fetchSchemaReadme(ocabundle: string): Promise<{
   ledgerUrl?: string;
   ledgerMap?: Map<string, { ledger: string; ledgerUrl?: string }>;
 }> {
-  // Check cache first
+  const now = Date.now();
+
+  // Check cache first (with TTL expiration)
   if (readmeCache.has(ocabundle)) {
-    return readmeCache.get(ocabundle)!;
+    const cached = readmeCache.get(ocabundle)!;
+    const cacheAge = now - cached.timestamp;
+    const ttl = cached.ledgerMap ? README_CACHE_TTL : README_FAIL_CACHE_TTL;
+    if (cacheAge < ttl) {
+      return { ledger: cached.ledger, ledgerUrl: cached.ledgerUrl, ledgerMap: cached.ledgerMap };
+    }
+    // Cache expired, remove it
+    readmeCache.delete(ocabundle);
   }
 
-  // Retry logic for failed fetches
-  const maxRetries = 2;
+  // Retry logic for failed fetches with exponential backoff
+  const maxRetries = 3;
   let lastError: Error | null = null;
 
   for (let attempt = 0; attempt <= maxRetries; attempt++) {
@@ -322,48 +338,57 @@ export async function fetchSchemaReadme(ocabundle: string): Promise<{
       const readmePath = ocabundle.replace("OCABundle.json", "README.md");
       const readmeUrl = `${GITHUB_RAW_URL}/${readmePath}`;
 
+      // Increased timeout for CI environments (30 seconds)
+      // Use AbortSignal.timeout if available, otherwise fallback
+      const timeoutMs = 30000;
+      const controller = new AbortController();
+      const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
+
       const response = await fetch(readmeUrl, {
-        // Add timeout to prevent hanging requests
-        signal: AbortSignal.timeout(10000) // 10 second timeout for README files
+        signal: controller.signal as AbortSignal
       });
+
+      clearTimeout(timeoutId);
 
       if (!response.ok) {
         // Don't log 404s as they're expected for many bundles
         if (response.status !== 404) {
           console.warn(`Failed to fetch README for ${ocabundle}: ${response.status}`);
         }
-        // Don't cache failed results - return empty without caching
+        // Cache the failure briefly to avoid hammering
+        readmeCache.set(ocabundle, { timestamp: now });
         return {};
       }
 
       const readmeContent = await response.text();
       const ledgerInfo = extractLedgerFromReadme(readmeContent);
 
-      // Cache the result only if we got meaningful data
-      if (ledgerInfo.ledgerMap && ledgerInfo.ledgerMap.size > 0) {
-        readmeCache.set(ocabundle, ledgerInfo);
-      }
+      // Cache the result with timestamp (even if empty, for short period)
+      readmeCache.set(ocabundle, { ...ledgerInfo, timestamp: now });
       return ledgerInfo;
     } catch (error) {
       lastError = error instanceof Error ? error : new Error(String(error));
-      // Only retry on timeout errors
-      if (lastError.name.includes('TimeoutError')) {
+      const isTimeout = lastError.name.includes('TimeoutError') ||
+                        lastError.message.includes('aborted');
+
+      if (isTimeout) {
         if (attempt < maxRetries) {
-          console.log(`Retry ${attempt + 1}/${maxRetries} for README: ${ocabundle}`);
+          // Exponential backoff: 2s, 4s, 8s with jitter
+          const delay = (Math.pow(2, attempt) * 1000) + Math.random() * 1000;
+          console.log(`Retry ${attempt + 1}/${maxRetries} for README: ${ocabundle} after ${Math.round(delay)}ms`);
+          await new Promise(resolve => setTimeout(resolve, delay));
           continue;
         }
-        // If we've reached the max retries, fall through and let the loop end
       } else {
-        // For non-timeout errors, stop retrying immediately
+        // For non-timeout errors, log and stop retrying
+        console.warn(`Error fetching README for ${ocabundle}:`, lastError.message);
         break;
       }
     }
   }
 
-  // Don't cache failed results - return empty without caching
-  if (lastError && !lastError.name.includes('TimeoutError')) {
-    console.warn(`Error fetching README for ${ocabundle}:`, lastError.message);
-  }
+  // Cache the failure briefly
+  readmeCache.set(ocabundle, { timestamp: now });
   return {};
 }
 

--- a/app/lib/data.ts
+++ b/app/lib/data.ts
@@ -388,7 +388,7 @@ export async function fetchSchemaReadme(ocabundle: string): Promise<{
   }
 
   // Cache the failure briefly
-  readmeCache.set(ocabundle, { timestamp: now });
+  readmeCache.set(ocabundle, { timestamp: Date.now() });
   return {};
 }
 


### PR DESCRIPTION
## Summary
Improves README fetch resilience to fix Issue #64 where LTSA Property Owner Credential bundle displays both credential IDs under CANDY_DEV instead of splitting between CANDY_DEV and CANDY_TEST.

## Changes
- Increase timeout from 10s to 30s for CI environments
- Add exponential backoff with jitter (2s, 4s, 8s) for retries
- Add TTL-based cache expiration (10min success, 30s failure)
- Cache failed fetches briefly to prevent hammering
- Increase max retries from 2 to 3

## Testing
- Verified locally via \yarn dev\ - LTSA bundle now correctly shows CANdy Development and CANdy Test as separate groupings
- Integration test confirmed both CANDY_DEV and CANDY_TEST entries are correctly parsed

## Issue
Fixes #64