### PR TITLE
Fix LTSA Property Owner Credential ledger display issue #64

### DIFF
--- a/app/lib/data.ts
+++ b/app/lib/data.ts
@@ -374,7 +374,7 @@ export async function fetchSchemaReadme(ocabundle: string): Promise<{
       if (isTimeout) {
         if (attempt < maxRetries) {
           // Exponential backoff: 2s, 4s, 8s with jitter
-          const delay = (Math.pow(2, attempt) * 1000) + Math.random() * 1000;
+          const delay = (Math.pow(2, attempt + 1) * 1000) + Math.random() * 1000;
           console.log(`Retry ${attempt + 1}/${maxRetries} for README: ${ocabundle} after ${Math.round(delay)}ms`);
           await new Promise(resolve => setTimeout(resolve, delay));
           continue;
@@ -515,11 +515,12 @@ export async function fetchOverlayBundleList(): Promise<BundleWithLedger[]> {
                     ledgerNormalized: normalized
                   };
                 } else {
-                  // Fallback: use the ledger's own info
+                  // Fallback: use the README's default ledger info, not the group's ledger
+                  // This handles cases where an ID wasn't found in ledgerInfo.ledgerMap
                   idLedgerMap[id] = {
-                    ledger: ledgerData.ledger,
-                    ledgerUrl: ledgerData.ledgerUrl,
-                    ledgerNormalized: ledgerNormalized
+                    ledger: ledgerInfo.ledger || 'unknown',
+                    ledgerUrl: ledgerInfo.ledgerUrl,
+                    ledgerNormalized: normalizeLedgerValue(ledgerInfo.ledger)
                   };
                 }
               }


### PR DESCRIPTION
## Summary
- Fix idLedgerMap fallback to use README's default ledger instead of group's ledger when an identifier is not found in ledgerMap
- Fix exponential backoff delay calculation (2s, 4s, 8s instead of 1s, 2s, 4s)

## Problem
Issue #64: LTSA Property Owner Credential bundle displays both credential definition IDs under CANDY_DEV ledger grouping, when they should be split between CANDY_DEV and CANDY_TEST.

## Root Cause
When the README fetch failed or returned partial data, identifiers not found in ledgerInfo.ledgerMap were falling back to the current group's ledger instead of the README's default ledger. Additionally, the exponential backoff was using incorrect delay values.

## Changes
- `app/lib/data.ts`:
  - Line 377: Fixed delay calculation from `2^attempt` to `2^(attempt+1)` for proper 2s, 4s, 8s delays
  - Lines 517-525: Changed fallback to use `ledgerInfo.ledger` instead of `ledgerData.ledger`

Signed-off-by: Kyle Robinson <kyle.robinson@briartech.ca>